### PR TITLE
annotate MenuItemSeparator and menu expand images to clarify menu counts

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/user/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -1169,6 +1169,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
       setItemColSpan(item, 1);
       Element td = DOM.createTD();
       td.setPropertyString("vAlign", "middle");
+      Roles.getPresentationRole().setAriaHiddenState(td, true);
       String indicatorHtml = subMenuIcon.getSafeHtml().asString();
       // add null alt attribute for a11y
       if (indicatorHtml.startsWith("<img") && indicatorHtml.endsWith(">"))

--- a/user/src/com/google/gwt/user/client/ui/MenuItemSeparator.java
+++ b/user/src/com/google/gwt/user/client/ui/MenuItemSeparator.java
@@ -15,6 +15,7 @@
  */
 package com.google.gwt.user.client.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 
@@ -39,6 +40,9 @@ public class MenuItemSeparator extends UIObject {
     Element div = DOM.createDiv();
     DOM.appendChild(getElement(), div);
     setStyleName(div, "menuSeparatorInner");
+
+    Roles.getSeparatorRole().set(getElement());
+    Roles.getSeparatorRole().setAriaDisabledState(getElement(), true);
   }
 
   /**


### PR DESCRIPTION
Without these changes, VoiceOver on macOS would count each separator as a menu item, but not move the VoiceOver cursor to them, and would count each expand image on menu items as another menu item (also unable to move to it); so reported menu item counts would be inconsistent to an unsighted user

<img width="242" alt="2019-12-02_12-51-50" src="https://user-images.githubusercontent.com/10569626/69994434-bc361400-1502-11ea-96af-7a29e759e1e6.png">
