### PR TITLE
use menu role instead of menubar role for dropdown menus per aria gui…

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/user/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -1253,7 +1253,10 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
     DOM.appendChild(outer, table);
     setElement(outer);
 
-    Roles.getMenubarRole().set(getElement());
+    if (vertical)
+      Roles.getMenuRole().set(getElement());
+    else
+      Roles.getMenubarRole().set(getElement());
     Roles.getPresentationRole().set(table);
 
     sinkEvents(Event.ONCLICK | Event.ONMOUSEOVER | Event.ONMOUSEOUT


### PR DESCRIPTION
- for whatever reason, this small change dramatically improves the behavior of VoiceOver / macOS when navigating the menus, see https://github.com/rstudio/rstudio/issues/5119
