### PR TITLE
Handle splitter adjustments for non-reverse panels

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/SplitLayoutPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/SplitLayoutPanel.java
@@ -209,12 +209,18 @@ public class SplitLayoutPanel extends DockLayoutPanel {
           {
           case KeyCodes.KEY_LEFT:
           case KeyCodes.KEY_UP:
-            delta = keyboardResizeDelta;
+            if (reverse)
+               delta = keyboardResizeDelta;
+            else
+               delta = -keyboardResizeDelta;
             break;
 
           case KeyCodes.KEY_RIGHT:
           case KeyCodes.KEY_DOWN:
-            delta = -keyboardResizeDelta;
+            if (reverse)
+               delta = -keyboardResizeDelta;
+            else
+               delta = keyboardResizeDelta;
             break;
           }
           if (delta != 0)


### PR DESCRIPTION
When I added functionality to adjust splitter positions for source columns, initially the left arrow key move the splitter to the right and the right arrow moved it to the left. Accounting for the panel's reverse flag ensures the splitters move in the expected direction. 