### PR TITLE
Option to have ESC key close only current menu

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/user/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -1363,7 +1363,6 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
 
   /*
    * This method is called when a menu bar is hidden, so that it can hide any
-   *
    * child popups that are currently being shown.
    */
   private void onHide(boolean focus) {

--- a/user/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/user/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -306,6 +306,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
   private MenuItem expandedMenuItem;
   private boolean vertical, autoOpen;
   private boolean focusOnHover = true;
+  private boolean escClosesAll = true;
 
   /**
    * Creates an empty horizontal menu bar.
@@ -802,7 +803,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
             eatEvent(event);
             break;
           case KeyCodes.KEY_ESCAPE:
-            closeAllParentsAndChildren();
+            handleEscKey();
             eatEvent(event);
             break;
           case KeyCodes.KEY_TAB:
@@ -963,6 +964,16 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    */
   public void setFocusOnHoverEnabled(boolean enabled) {
     focusOnHover = enabled;
+  }
+
+  /**
+   * Set whether hitting ESC key causes all popups to close (the default GWT
+   * behavior) or just the current one (typical Windows desktop menu behavior).
+   *
+   * @param closesAll true to close all menu popups, false to only close this one
+   */
+  public void setEscClosesAll(boolean closesAll) {
+    escClosesAll = closesAll;
   }
 
   /**
@@ -1324,6 +1335,16 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
     }
   }
 
+  private void handleEscKey() {
+    if (escClosesAll || !vertical || parentMenu == null) {
+      // Default GWT behavior or if we're on the top-level menubar
+      closeAllParentsAndChildren();
+    } else {
+      // Otherwise close this menu and focus the parent
+      close(true);
+    }
+  }
+
   private void moveToPrevItem() {
     if (selectFirstItemIfNoneSelected()) {
       return;
@@ -1342,6 +1363,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
 
   /*
    * This method is called when a menu bar is hidden, so that it can hide any
+   *
    * child popups that are currently being shown.
    */
   private void onHide(boolean focus) {


### PR DESCRIPTION
Added an option for GWT menus to have ESC keypress only collapse the current level of an expanded menu and move focus to parent, instead of collapsing an entire tree of displayed menus.

Will be used to fix https://github.com/rstudio/rstudio/issues/6327 

New behavior is opt-in, and will only be enabled on the RStudio Server main menu.