### PR TITLE
avoid issue when accessing className for SVG elements

### DIFF
--- a/user/src/com/google/gwt/dom/client/Element.java
+++ b/user/src/com/google/gwt/dom/client/Element.java
@@ -206,8 +206,8 @@ public class Element extends Node {
    *      HTML Specification</a>
    */
   public final native String getClassName() /*-{
-     return this.className || "";
-   }-*/;
+    return (this.classList || {}).value || this.className || "";
+  }-*/;
 
   /**
    * Returns the inner height of an element in pixels, including padding but not


### PR DESCRIPTION
This PR fixes an issue when attempting to access the class name of an SVG element.

The className property of an SVG element may not actually be a regular JavaScript string; rather, it can be an [SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString), which unfortunately cannot be treated as a "plain" string.

<img width="378" alt="Screen Shot 2021-02-18 at 12 20 25 PM" src="https://user-images.githubusercontent.com/1976582/108416553-b6018580-71e3-11eb-87be-18f434b1a262.png">


The `classList` property, however, is a [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) which typically has a `value` attribute, indicating the regular "string" value of that list. This appears to work fine for SVG elements.